### PR TITLE
NOC-459 resolve missing career profile info on preview card.

### DIFF
--- a/src/web/themes/custom/bcgov_career/templates/views/views-view-table--career_matches.html.twig
+++ b/src/web/themes/custom/bcgov_career/templates/views/views-view-table--career_matches.html.twig
@@ -238,7 +238,7 @@
                   {% for field in column.fields %}
                     {% set field_nm = field_nm ~ field %}
                   {% endfor %}
-                  {% if field_nm == 'field-median-salary'%}
+                  {% if 'field-median-salary' in field_nm %}
                     <p class="data-item"><span class="f-d">Annual Salary</span><span class="s-d">
                       {%- if column.wrapper_element -%}
                         <{{ column.wrapper_element }}>
@@ -261,7 +261,7 @@
                       {%- endif %}
                     </span></p>
                   {% endif %}
-                  {% if field_nm == 'field-education-level'%}
+                  {% if 'field-education-level' in field_nm %}
                     <p class="data-item"><span class="f-d">Training, Education, Experience and Responsibilities</span><span class="s-d">
                       {%- if column.wrapper_element -%}
                         <{{ column.wrapper_element }}>


### PR DESCRIPTION
field_nm contained a trailing " is-active" when sorting by salary or education.  This caused a false  if condition and the info not being displayed.