### PR TITLE
NOC-459 resolve missing education level issue, remove debug code

### DIFF
--- a/src/web/themes/custom/bcgov_career/templates/content/node--career-profile--full.html.twig
+++ b/src/web/themes/custom/bcgov_career/templates/content/node--career-profile--full.html.twig
@@ -67,7 +67,6 @@
  *
  */
 #}
-{{ dump(node) }}
 {%
   set classes = [
     'node',

--- a/src/web/themes/custom/bcgov_career/templates/views/views-view-table--career_matches.html.twig
+++ b/src/web/themes/custom/bcgov_career/templates/views/views-view-table--career_matches.html.twig
@@ -152,7 +152,6 @@
                   {% if row.raw.nid is not empty %}
                     {% set nodeURL =  url('entity.node.canonical', {'node': row.raw.nid}) %}
                   {% endif %}
-
                     {% if field_nm == 'field-noc-name' %}
                       <td>
                         {% if row.raw.match is not empty %}
@@ -177,7 +176,7 @@
                           <span class="checkmark"></span>
                         </label>
                       </td>
-                    {% elseif field_nm == 'field-median-salary' or field_nm == 'field-education-level' %}
+                    {% elseif field_nm == 'field-median-salary' or field_nm == 'field-teer' %}
                       <td{{ column.attributes.addClass(column_classes) }} >
                         {%- if column.wrapper_element -%}
                           <{{ column.wrapper_element }}>
@@ -261,7 +260,7 @@
                       {%- endif %}
                     </span></p>
                   {% endif %}
-                  {% if 'field-education-level' in field_nm %}
+                  {% if 'field-teer' in field_nm %}
                     <p class="data-item"><span class="f-d">Training, Education, Experience and Responsibilities</span><span class="s-d">
                       {%- if column.wrapper_element -%}
                         <{{ column.wrapper_element }}>


### PR DESCRIPTION
My fix for NOC-460 broke the Education level display on the Career Match preview card. This fixes the issue.

![Abilities-Quiz-Results-Career-Discovery-Quizzes (12)](https://github.com/bcgov/workbc-cc/assets/1471584/426cf205-004c-4d05-86ab-e3fc677ce322)

![iPhone-15-v17-3 (2)](https://github.com/bcgov/workbc-cc/assets/1471584/96903e52-0e46-44a9-b9b6-9b7ecc4af31e)
