### PR TITLE
[WBCAMS-789] Fix checkboxes for career comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Career Discovery Quizzes, a subsite of [WorkBC.ca](https://www.workbc.ca).
   - `docker-compose exec php sudo chown www-data /var/www/html/web/sites/default/files`
 - Import the data dumps:
   - `gunzip -k -c src/scripts/workbc-cc.sql.gz | docker-compose exec -T postgres psql -U workbc workbc-cc-refactor`
-  - Restore the SSOT data dump as per the [`workbc-ssot` README](https://github.com/bcgov/workbc-ssot?tab=readme-ov-file#development)
+  - Restore the SSOT data dump as per the [`workbc-ssot` README](https://github.com/bcgov/workbc-ssot?tab=readme-ov-file#development). Assuming your SSOT repo lives at `../workbc-ssot`:
+  ```bash
+  docker-compose exec -T postgres psql --username workbc ssot < ../workbc-ssot/ssot-reset.sql \
+  && gunzip -k -c ../workbc-ssot/ssot-full.sql.gz | docker-compose exec -T postgres psql --username workbc ssot \
+  && docker-compose kill -s SIGUSR1 ssot
+  ```
 - Edit your `hosts` file to add the following line:
 ```
 127.0.0.1       workbc-cc.docker.localhost

--- a/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
+++ b/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
@@ -102,19 +102,6 @@
           $('#modifyNextLinks').hide()
         });
 
-        // when user clicks back-to-quiz link (MOBILE only)
-        $('a#back-to-quiz').on('click', function() {
-          $('.cdq-results').each(function() {
-            $(this).removeClass("user-selected");
-          });
-
-          $('.career-content-item').each(function() {
-            $(this).removeClass("active");
-          });
-          $('#modifyNextLinks').show()
-          $("html, body").animate({scrollTop: $(".careers-mobi-table-wrapper").offset().top}, "slow");
-        });
-
         function totalSelected() {
           let total = 0;
           let target = ".careers-main-wrapper .compare-career-checkbox";
@@ -217,48 +204,42 @@
         });
       });
 
-        $(".carousel-mobi-tabs-trigger").on("click", function () {
-          $(this).next().addClass("active");
-          $("body").addClass("overlayBg");
-        });
-        $(".carousel-mobi-tab-close").on("click", function () {
-          $(this).parent().removeClass("active");
-          $("body").removeClass("overlayBg");
-        });
-        $(".carousel-mobi-tab-item").on("click", function () {
-          $(".carousel-mobi-tab-item").removeClass("active");
-          $(this).addClass("active");
+      $(".carousel-mobi-tabs-trigger").on("click", function () {
+        $(this).next().addClass("active");
+        $("body").addClass("overlayBg");
+      });
+      $(".carousel-mobi-tab-close").on("click", function () {
+        $(this).parent().removeClass("active");
+        $("body").removeClass("overlayBg");
+      });
+      $(".carousel-mobi-tab-item").on("click", function () {
+        $(".carousel-mobi-tab-item").removeClass("active");
+        $(this).addClass("active");
 
-          const getTabItemId = $(this).data("href");
-          if (getTabItemId == "bottomcarousel") {
-            $(this)
-              .parents("#myResult")
-              .find(".extradivs")
-              .addClass("displayMobiPrint");
-          } else {
-            $(this)
-              .parents("#myResult")
-              .find(".extradivs")
-              .removeClass("displayMobiPrint");
-          }
-          $(".carousel-inner-mobi").removeClass("active");
-          $(`.carousel-inner-mobi[data-id=${getTabItemId}]`).addClass("active");
-          $(".active > .carousel-slider-mobi-row").slick(
-            "slickGoTo",
-            parseInt(0),
-            true
-          );
+        const getTabItemId = $(this).data("href");
+        if (getTabItemId == "bottomcarousel") {
+          $(this)
+            .parents("#myResult")
+            .find(".extradivs")
+            .addClass("displayMobiPrint");
+        } else {
+          $(this)
+            .parents("#myResult")
+            .find(".extradivs")
+            .removeClass("displayMobiPrint");
+        }
+        $(".carousel-inner-mobi").removeClass("active");
+        $(`.carousel-inner-mobi[data-id=${getTabItemId}]`).addClass("active");
+        $(".active > .carousel-slider-mobi-row").slick(
+          "slickGoTo",
+          parseInt(0),
+          true
+        );
 
-          $(this).parent().parent().removeClass("active");
-          $("body").removeClass("overlayBg");
+        $(this).parent().parent().removeClass("active");
+        $("body").removeClass("overlayBg");
 
-          $(".carousel-mobi-tabs-trigger > span.text").text($(this).data("text"));
-        });
-
-      $(once('cdqcareercompare', '.cdq-back-link', context)).each(function () {
-        $(".back-to-results").on("click", function () {
-          history.back();
-        });
+        $(".carousel-mobi-tabs-trigger > span.text").text($(this).data("text"));
       });
 
       $(once('cdqprint', '.career-top-right', context)).each(function () {
@@ -317,13 +298,13 @@
               }
               const content = document.getElementById("block-workbc-cdq-content");
               content.scrollIntoView({ behavior: "smooth", block: "end" });
-             
+
             }
           }
       );
 
 
-    } 
+    }
   };
 
 })(Drupal, jQuery, once, drupalSettings);

--- a/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/Block/ReturnToResultsBlock.php
+++ b/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/Block/ReturnToResultsBlock.php
@@ -25,11 +25,6 @@ class ReturnToResultsBlock extends BlockBase {
    */
   public function build() {
 
-    global $base_url;
-
-    $theme = \Drupal::theme()->getActiveTheme();
-    $default_image_url = $base_url.'/'. $theme->getPath() .'/images/image.jpg';
-
     $path = \Drupal::service('path.current')->getPath();
     $path = explode("/", $path);
     $submission = WebformSubmission::load($path[2]);
@@ -38,11 +33,12 @@ class ReturnToResultsBlock extends BlockBase {
       'query' => ['token' => $submission->getToken()]
     ])->toString();
 
-    $markup = "";
-    $markup .= '<div class="cdq-back-link">';
-    $markup .= '<a href="#back" class="back-to-results"><img src="/themes/custom/workbc_cdq/assets/arrow-left.svg"/> Back to Quiz Results </a>';
-    $markup .= '</div>';
-  
+    $markup = <<<END
+      <div class="cdq-back-link">
+        <a href="$results_link" class="back-to-results"><img src="/themes/custom/workbc_cdq/assets/arrow-left.svg"/>Back to Quiz Results</a>
+      </div>
+    END;
+
     return array(
       '#type' => 'markup',
       '#markup' => $markup,


### PR DESCRIPTION
As per WBCAMS-789, the issue is that the following sequence yields incorrect results:
- Select some careers for comparison by checking their checkboxes
- Click "Compare Careers"
- Click "Back to Quiz Results" button
=> The "Clear Compare" / "Compare Careers" buttons are enabled
- Click "Clear Compare"
- Select some careers for comparison by checking their checkboxes
- Click "Compare Careers"
- Click "Back to Quiz Results" button
=> The "Clear Compare" / "Compare Careers" buttons are disabled, whereas they should be still enabled

I traced the issue to the interaction of the Back button / browser history with the JavaScript that runs when loading the results page. Several problems exist on this page:
- Duplication of DOM structures between mobile and desktop views
- Absence of unique IDs for all checkbox inputs

Compounded with the behaviour of the Back button, it's a complex issue. To keep the fix simple, I am eliminating the Back button behaviour and replacing the back link with an actual reloading of the results page.