### PR TITLE
[WBCAMS-838] fix bug when only two career profiles are selected.

### DIFF
--- a/src/web/themes/custom/workbc_cdq/js/snowplow-tracker.js
+++ b/src/web/themes/custom/workbc_cdq/js/snowplow-tracker.js
@@ -152,13 +152,13 @@
             let noc_2 = null;
             let noc_3 = null;
 
-            if(noc_group['noc_1'] != '') {
+            if('noc_1' in noc_group && noc_group['noc_1'] != '') {
                 noc_1 = noc_group['noc_1'].toString();
             }
-            if(noc_group['noc_2'] != '') {
+            if('noc_2' in noc_group && noc_group['noc_2'] != '') {
                 noc_2 = noc_group['noc_2'].toString();
             }
-            if(noc_group['noc_3'] != '') {
+            if('noc_3' in noc_group && noc_group['noc_3'] != '') {
                 noc_3 = noc_group['noc_3'].toString();
             }
             window.snowplow('trackSelfDescribingEvent', {"schema":"iglu:ca.bc.gov.workbc/career_quiz_compare/jsonschema/1-0-0",


### PR DESCRIPTION
While looking into another ticket I discovered a bug in my code implementing WBCAMS-838 fix.  If only two careers are selected the code would generate an error.  This would not only fail to send snowplow data it would also cause the Clear Compare to fail.

Added checking to see if a value exists, passing a string if it exists and null if it doesn't.