### PR TITLE
[WBCAMS-1057] error message when modifying quiz results

### DIFF
--- a/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/CareerMatchWebformHandler.php
+++ b/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/CareerMatchWebformHandler.php
@@ -51,6 +51,7 @@ class CareerMatchWebformHandler extends WebformHandlerBase {
 
     $request = \Drupal::request();
     $session = $request->getSession();
+    \Drupal::logger('workbc_cdq_career_match')->notice("CareerMatch - set @quiz_id token @token", array('@quiz_id' => $webform_submission->getWebform()->id(), '@token' => $webform_submission->getToken()));
     $session->set($webform_submission->getWebform()->id().'_token', $webform_submission->getToken());
 
     $scores = getSubmissionScore($webform_submission);

--- a/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/CareerMatchWebformHandler.php
+++ b/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/CareerMatchWebformHandler.php
@@ -47,12 +47,15 @@ class CareerMatchWebformHandler extends WebformHandlerBase {
    * {@inheritdoc}
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
-    if ($webform_submission->getState() !== WebformSubmissionInterface::STATE_COMPLETED) return;
 
-    $request = \Drupal::request();
-    $session = $request->getSession();
-    \Drupal::logger('workbc_cdq_career_match')->notice("CareerMatch - set @quiz_id token @token", array('@quiz_id' => $webform_submission->getWebform()->id(), '@token' => $webform_submission->getToken()));
-    $session->set($webform_submission->getWebform()->id().'_token', $webform_submission->getToken());
+    if ($webform_submission->getState() == WebformSubmissionInterface::STATE_DRAFT_CREATED || 
+        $webform_submission->getState() == WebformSubmissionInterface::STATE_COMPLETED) {
+      $request = \Drupal::request();
+      $session = $request->getSession();
+      $session->set($webform_submission->getWebform()->id().'_token', $webform_submission->getToken());
+    }
+    
+    if ($webform_submission->getState() !== WebformSubmissionInterface::STATE_COMPLETED) return;
 
     $scores = getSubmissionScore($webform_submission);
     $matches = matchCareers($webform_submission, $scores);

--- a/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/SessionQuizTokenWebformHandler.php
+++ b/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/SessionQuizTokenWebformHandler.php
@@ -39,9 +39,16 @@ class SessionQuizTokenWebformHandler extends WebformHandlerBase {
    * {@inheritdoc}
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
-    $request = \Drupal::request();
-    $session = $request->getSession();
-    $session->set($webform_submission->getWebform()->id().'_token', $webform_submission->getToken());
+    
+    \Drupal::logger('workbc_cdq_career_match')->notice("Session Quiz -oken @token", array('@quiz_id' => $webform_submission->getWebform()->id(), '@token' => $webform_submission->getToken()));
+    
+    $form = \Drupal::request()->get('ajax_form');
+    if (is_null($form)) {
+      $request = \Drupal::request();
+      $session = $request->getSession();
+      \Drupal::logger('workbc_cdq_career_match')->notice("Session Quiz - set @quiz_id token @token", array('@quiz_id' => $webform_submission->getWebform()->id(), '@token' => $webform_submission->getToken()));
+      $session->set($webform_submission->getWebform()->id().'_token', $webform_submission->getToken());
+    }
   }
 
 

--- a/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/SessionQuizTokenWebformHandler.php
+++ b/src/web/modules/custom/workbc_cdq_career_match/src/Plugin/WebformHandler/SessionQuizTokenWebformHandler.php
@@ -39,14 +39,11 @@ class SessionQuizTokenWebformHandler extends WebformHandlerBase {
    * {@inheritdoc}
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
-    
-    \Drupal::logger('workbc_cdq_career_match')->notice("Session Quiz -oken @token", array('@quiz_id' => $webform_submission->getWebform()->id(), '@token' => $webform_submission->getToken()));
-    
-    $form = \Drupal::request()->get('ajax_form');
-    if (is_null($form)) {
+
+    if ($webform_submission->getState() == WebformSubmissionInterface::STATE_DRAFT_CREATED || 
+        $webform_submission->getState() == WebformSubmissionInterface::STATE_COMPLETED) {
       $request = \Drupal::request();
       $session = $request->getSession();
-      \Drupal::logger('workbc_cdq_career_match')->notice("Session Quiz - set @quiz_id token @token", array('@quiz_id' => $webform_submission->getWebform()->id(), '@token' => $webform_submission->getToken()));
       $session->set($webform_submission->getWebform()->id().'_token', $webform_submission->getToken());
     }
   }


### PR DESCRIPTION
The code for saving tokens has been repositioned in CareerMatchWebformHandler.php.  Previously the token was only saved on quiz completion and as a result the Continue Quiz functionality for the Career Quizzes was not working.