### PR TITLE
[WBCAMS-1199] add Tools and Resource section title string override

### DIFF
--- a/src/config/sync/stringoverrides.string_override.en.yml
+++ b/src/config/sync/stringoverrides.string_override.en.yml
@@ -53,3 +53,6 @@ contexts:
       -
         source: resource_4_title
         translation: 'High Opportunity Occupations'
+      -
+        source: resources_section_title
+        translation: 'Tools and Resources'

--- a/src/web/themes/custom/workbc_cdq/templates/includes/front-page-resources.html.twig
+++ b/src/web/themes/custom/workbc_cdq/templates/includes/front-page-resources.html.twig
@@ -3,9 +3,9 @@
      <div class="row">
        <div class="col-12">
          <div class="title">
-           <h2>Tools and Resources</h2>
+           <h2>{{ resources_section_title }}</h2>
          </div>
-         <div class="field field--name-field-title field--type-string field--label-hidden field__item">Tools and Resources</div>
+         <div class="field field--name-field-title field--type-string field--label-hidden field__item">{{ resources_section_title }}</div>
          <div class="tools-resource-items-wrapper">
            <div class="field__items row">
              <div class="col-12 col-md-3">

--- a/src/web/themes/custom/workbc_cdq/workbc_cdq.theme
+++ b/src/web/themes/custom/workbc_cdq/workbc_cdq.theme
@@ -41,6 +41,8 @@ function workbc_cdq_preprocess_page(&$variables) {
     $variables['text']['home_page_personality_title'] = t('home_page_personality_title');
     $variables['text']['home_page_personality_text'] = t('home_page_personality_text');
 
+    $variables['resources_section_title'] = t('resources_section_title');
+
     $variables['resources'][0]['title'] = t('resource_1_title');
     $variables['resources'][0]['link'] = t('resource_1_link');
     $variables['resources'][0]['description'] = t('resource_1_description');


### PR DESCRIPTION
While preparing testing and usage notes I realized I forgot to add the ability to edit the Tools and Resources section title.