### PR TITLE
[WBCAMS-1920] allow for Quiz lifespan hours setting of 0, update field description

### DIFF
--- a/src/web/modules/custom/workbc_cdq_custom/src/Form/AdminSettingsForm.php
+++ b/src/web/modules/custom/workbc_cdq_custom/src/Form/AdminSettingsForm.php
@@ -34,11 +34,11 @@ class AdminSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('workbc_cdq_custom.settings');
 
-    $default =  $config->get('results_lifespan') ? $config->get('results_lifespan') : 336;
+    $default = !is_null($config->get('results_lifespan')) ? $config->get('results_lifespan') : 336;
     $form['results_lifespan'] = [
       '#type' => 'number',
       '#title' => $this->t('Quiz lifespan hours'),
-      '#description' => 'Quiz results lifespan in hours before they are purged from the system',
+      '#description' => 'Quiz results lifespan in hours before they are purged from the system. Enter 0 to suspend purging quiz results.',
       '#default_value' => $default,
     ];
 


### PR DESCRIPTION
Default value is only set to 336 if setting value is null, this allows for a setting of 0 to suspend/rest purging.