### PR TITLE
[WBCAMS-1467] career match unique urls

### DIFF
--- a/src/config/sync/views.view.cdq_compare_careers.yml
+++ b/src/config/sync/views.view.cdq_compare_careers.yml
@@ -579,7 +579,7 @@ display:
         type: some
         options:
           offset: 0
-          items_per_page: 5
+          items_per_page: 3
       exposed_form:
         type: basic
         options:
@@ -624,6 +624,21 @@ display:
             label: ''
             field_identifier: ''
           exposed: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments:
         sid:
           id: sid
@@ -659,45 +674,47 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-      filters:
-        selected:
-          id: selected
-          table: workbc_cdq_career_match
-          field: selected
-          relationship: none
+        field_noc_value:
+          id: field_noc_value
+          table: node__field_noc
+          field: field_noc_value
+          relationship: nid
           group_type: group
           admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+          plugin_id: string
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: ''
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: nocs
+            fallback: all
+            multiple: or
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+      filters: {  }
       filter_groups:
         operator: AND
         groups: {  }

--- a/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
+++ b/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
@@ -166,7 +166,7 @@
       function updateCompareCareersURL() {
         nocs = nocsSelected();
 
-        const links = document.querySelectorAll('.compare-career');
+        const links = $.find('.compare-career');
         links.forEach(link => {
           link.href = link.href.split("?")[0] + "?nocs=" + nocs.join("+");
         });

--- a/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
+++ b/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
@@ -39,6 +39,7 @@
             $('.clear-compare').addClass("disable");
             $('.compare-career').addClass("disable");
           }
+          updateCompareCareersURL();
         });
 
         $('.clear-compare').on('click', function() {
@@ -125,27 +126,51 @@
           $('#modifyNextLinks').show();
         });
 
-
-        function totalSelected() {
-          let total = 0;
-          let target = ".careers-main-wrapper .compare-career-checkbox";
-
-          if ($('#mobi-career-table').css('display') == "block") {
-            target = ".careers-mobi-main-wrapper .compare-career-checkbox";
-          }
-          $(target).each(function() {
-            if ($(this).is(':checked')) {
-              total++;
-            }
-          });
-          return total;
-        }
-
         if (totalSelected() > 1) {
           $('.clear-compare').removeClass("disable");
           $('.compare-career').removeClass("disable");
         }
+        updateCompareCareersURL();
       });
+
+      function totalSelected() {
+        let total = 0;
+        let target = ".careers-main-wrapper .compare-career-checkbox";
+
+        if ($('#mobi-career-table').css('display') == "block") {
+          target = ".careers-mobi-main-wrapper .compare-career-checkbox";
+        }
+        $(target).each(function() {
+          if ($(this).is(':checked')) {
+            total++;
+          }
+        });
+        return total;
+      }
+
+      function nocsSelected() {
+        let target = ".careers-main-wrapper .compare-career-checkbox";
+        let list = [];
+
+        if ($('#mobi-career-table').css('display') == "block") {
+          target = ".careers-mobi-main-wrapper .compare-career-checkbox";
+        }
+        $(target).each(function() {
+          if ($(this).is(':checked')) {
+            list.push($(this).attr('data-career-match-noc'));
+          }
+        });
+        return list;
+      }
+
+      function updateCompareCareersURL() {
+        nocs = nocsSelected();
+
+        const links = document.querySelectorAll('.compare-career');
+        links.forEach(link => {
+          link.href = link.href.split("?")[0] + "?nocs=" + nocs.join("+");
+        });
+      }
 
       $(once('main-content', '.category-results-toggle', context)).each(function () {
         $(this).on('click', function () {

--- a/src/web/modules/custom/workbc_cdq_career_match/workbc_cdq_career_match.module
+++ b/src/web/modules/custom/workbc_cdq_career_match/workbc_cdq_career_match.module
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\views\ViewExecutable;
 
 define ("NEW_LINE", "%0D%0A");
 
@@ -793,9 +794,12 @@ function workbc_cdq_career_match_tokens($type, $tokens, array $data, array $opti
         $replacements[$original] = $data['submission']->getWebform()->get('title');;
         break;
       case 'compare-careers-link':
+        $nocs = \Drupal::request()->query->get('nocs');
+        $nocs = "?nocs=" . str_replace(" ", "+", $nocs);
+
         $home_link = Url::fromRoute('<front>', [], $options)->toString();
         if (isset($data['submission'])) {
-          $replacements[$original] = $home_link . "compare-careers/" . $data['submission']->id();
+          $replacements[$original] = $home_link . "compare-careers/" . $data['submission']->id() . $nocs;
         }
         else {
           $replacements[$original] = $home_link;
@@ -831,3 +835,29 @@ function workbc_cdq_career_match_tokens($type, $tokens, array $data, array $opti
   return $replacements;
 }
 
+/**
+ * Implements hook_views_pre_view().
+ */
+function workbc_cdq_career_match_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
+
+  if ($view->id() == 'cdq_compare_careers' && $display_id == 'page_1') {
+    $nocs = \Drupal::request()->query->get('nocs');
+    // if no query parameter provided, use selected nocs else use 'all' to display first 3 careers.
+    if ($nocs == "") {
+      $database = \Drupal::database();
+      $query = $database->select('workbc_cdq_career_match', 'cm');
+      $query->join('node__field_noc', 'noc', 'noc.entity_id=cm.nid');
+      $query->fields('cm', ['id', 'sid', 'selected']);
+      $query->fields('noc', ['field_noc_value']);
+      $query->condition('cm.sid', $args[0], '=');
+      $query->condition('cm.selected', 1, '=');
+      $result = $query->execute()->fetchAll(\PDO::FETCH_ASSOC);
+
+      $parameters = "all";
+      if ($result) {
+        $parameters = implode('+', array_column($result, 'field_noc_value'));
+      }
+      \Drupal::request()->query->set('nocs', $parameters);
+    }
+  }
+}


### PR DESCRIPTION
In scenarios where a query parameters is not provided or has empty value, the result would be a "The requested page could not be found." message.  I added the hook_pre_view() to handle these situations.
