### PR TITLE
[WBCAMS-1467] update compare careers page email to use path arguments

### DIFF
--- a/src/config/sync/views.view.cdq_compare_careers.yml
+++ b/src/config/sync/views.view.cdq_compare_careers.yml
@@ -674,26 +674,24 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-        field_noc_value:
-          id: field_noc_value
+        field_noc_value_1:
+          id: field_noc_value_1
           table: node__field_noc
           field: field_noc_value
           relationship: nid
           group_type: group
           admin_label: ''
           plugin_id: string
-          default_action: default
+          default_action: ignore
           exception:
-            value: ''
+            value: all
             title_enable: false
-            title: ''
+            title: All
           title_enable: false
           title: ''
-          default_argument_type: query_parameter
+          default_argument_type: fixed
           default_argument_options:
-            query_param: nocs
-            fallback: ''
-            multiple: or
+            argument: ''
           summary_options:
             base_path: ''
             count: true
@@ -703,10 +701,10 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: true
+          specify_validation: false
           validate:
             type: none
-            fail: empty
+            fail: 'not found'
           validate_options: {  }
           glossary: false
           limit: 0
@@ -782,7 +780,7 @@ display:
     position: 2
     display_options:
       display_extenders: {  }
-      path: compare-careers/%
+      path: compare-careers/%sid/%noc/%noc
     cache_metadata:
       max-age: -1
       contexts:

--- a/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
+++ b/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
@@ -168,7 +168,9 @@
 
         const links = $.find('.compare-career');
         links.forEach(link => {
-          link.href = link.href.split("?")[0] + "?nocs=" + nocs.join("+");
+          const parts = link.href.split("/compare-careers/");
+          parts.slice(0, 0, '/compare-careers/');
+          link.href = [parts[0], "compare-careers", parts[1].split('/')[0], nocs.join("+")].join("/");
         });
       }
 

--- a/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
+++ b/src/web/modules/custom/workbc_cdq_career_match/js/workbc-cdq-career-match.js
@@ -169,7 +169,6 @@
         const links = $.find('.compare-career');
         links.forEach(link => {
           const parts = link.href.split("/compare-careers/");
-          parts.slice(0, 0, '/compare-careers/');
           link.href = [parts[0], "compare-careers", parts[1].split('/')[0], nocs.join("+")].join("/");
         });
       }

--- a/src/web/modules/custom/workbc_cdq_career_match/workbc_cdq_career_match.module
+++ b/src/web/modules/custom/workbc_cdq_career_match/workbc_cdq_career_match.module
@@ -125,7 +125,7 @@ function workbc_cdq_career_match_views_pre_render($view) {
 
   if ($view->id() === 'cdq_compare_careers' && $view->current_display === 'page_1') {
     $message = 'Quiz results have changed since this comparison was created. Some careers are no longer part of the result set.';
-    $nocs = \Drupal::request()->query->get('nocs');
+    $nocs = $view->args[1];
     // Check if the view returned zero database rows
     if (empty($view->result)) {
       // check if submission still exists
@@ -147,7 +147,7 @@ function workbc_cdq_career_match_views_pre_render($view) {
       }
     }
     else {
-      $nocs = explode(' ', $nocs);
+      $nocs = explode(' ', $view->args[1]);
       $database = \Drupal::database();
       $query = $database->select('workbc_cdq_career_match', 'cm');
       $query->join('node__field_noc', 'noc', 'noc.entity_id=cm.nid');
@@ -834,12 +834,10 @@ function workbc_cdq_career_match_tokens($type, $tokens, array $data, array $opti
         $replacements[$original] = $data['submission']->getWebform()->get('title');;
         break;
       case 'compare-careers-link':
-        $nocs = \Drupal::request()->query->get('nocs');
-        $nocs = "?nocs=" . str_replace(" ", "+", $nocs);
-
+        $current_path = str_replace(" ", "+", \Drupal::service('path.current')->getPath());
         $home_link = Url::fromRoute('<front>', [], $options)->toString();
         if (isset($data['submission'])) {
-          $replacements[$original] = $home_link . "compare-careers/" . $data['submission']->id() . $nocs;
+          $replacements[$original] = $home_link . $current_path;
         }
         else {
           $replacements[$original] = $home_link;


### PR DESCRIPTION
It is possible to use multiple values in Views path arguments.  

a Second argument has been added to provide NOCs for the Compare Careers view.

`/compare-careers/11503/13110+31111+45633`

I manually created a mailto link on CDQ DEV and tested with my Android tablet.