### PR TITLE
[WBCAMS-1467] custom compare careers url

### DIFF
--- a/src/config/sync/views.view.cdq_compare_careers.yml
+++ b/src/config/sync/views.view.cdq_compare_careers.yml
@@ -780,7 +780,7 @@ display:
     position: 2
     display_options:
       display_extenders: {  }
-      path: compare-careers/%sid/%noc/%noc
+      path: compare-careers/%sid/%noc
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
remove unnecessary configuration that generated an error while clearing cache and causing deployment to time  out.